### PR TITLE
Borrowing arguments ("Alan writes a web framework")

### DIFF
--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -198,6 +198,8 @@ where
 
 Alan is still not sure whether it can be simplified.
 
+Later on, other developers on the project attempt to extend this approach to work with closures, but they encounter limitations in rustc that seem to make it not work ([rust-lang/rust#70263](https://github.com/rust-lang/rust/issues/70263)).
+
 When Alan sees another open source project struggling with the same issue, he notices that Barbara has helped them out as well. Alan wonders how many people in the community would be able to write `.to_async_borrowing()` without help.
 
 ## 🤔 Frequently Asked Questions

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -1,4 +1,4 @@
-# 😱 Status quo stories: Template
+# 😱 Status quo stories: Alan writes a web framework
 
 
 [How To Vision: Status Quo]: ../how_to_vision/status_quo.md

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -1,0 +1,50 @@
+# 😱 Status quo stories: Template
+
+*This is a template for adding new "status quo" stories. To propose a new status quo PR, do the following:*
+
+* *Create a new file in the [`status_quo`] directory named something like `Alan_tries_to_foo.md` or `Grace_does_bar.md`, and start from [the raw source from this template]. You can replace all the italicized stuff. :)*
+* *Do not add a link to your story to the [`SUMMARY.md`] file; we'll do it after merging, otherwise there will be too many conflicts.*
+
+*For more detailed instructions, see the [How To Vision: Status Quo] page!*
+
+*If you're looking for ideas of what to write about, take a look at the [open issues]. You can also [open an issue of your own] to throw out an idea for others.*
+
+[How To Vision: Status Quo]: ../how_to_vision/status_quo.md
+[the raw source from this template]: https://raw.githubusercontent.com/rust-lang/wg-async-foundations/master/src/vision/status_quo/template.md
+[`status_quo`]: https://github.com/rust-lang/wg-async-foundations/tree/master/src/vision/status_quo
+[`SUMMARY.md`]: https://github.com/rust-lang/wg-async-foundations/blob/master/src/SUMMARY.md
+[open issues]: https://github.com/rust-lang/wg-async-foundations/issues?q=is%3Aopen+is%3Aissue+label%3Astatus-quo-story-ideas
+[open an issue of your own]: https://github.com/rust-lang/wg-async-foundations/issues/new?assignees=&labels=good+first+issue%2C+help+wanted%2C+status-quo-story-ideas&template=-status-quo--story-issue.md&title=
+
+
+## 🚧 Warning: Draft status 🚧
+
+This is a draft "status quo" story submitted as part of the brainstorming period. It is derived from real-life experiences of actual Rust users and is meant to reflect some of the challenges that Async Rust programmers face today. 
+
+If you would like to expand on this story, or adjust the answers to the FAQ, feel free to open a PR making edits (but keep in mind that, as they reflect peoples' experiences, status quo stories [cannot be wrong], only inaccurate). Alternatively, you may wish to [add your own status quo story][htvsq]!
+
+## The story
+
+*Write your story here! Feel free to add subsections, citations, links, code examples, whatever you think is best.*
+
+## 🤔 Frequently Asked Questions
+
+*Here are some standard FAQ to get you started. Feel free to add more!*
+
+* **What are the morals of the story?**
+    * *Talk about the major takeaways-- what do you see as the biggest problems.*
+* **What are the sources for this story?**
+    * *Talk about what the story is based on, ideally with links to blog posts, tweets, or other evidence.*
+* **Why did you choose *NAME* to tell this story?**
+    * *Talk about the character you used for the story and why.*
+* **How would this story have played out differently for the other characters?**
+    * *In some cases, there are problems that only occur for people from specific backgrounds, or which play out differently. This question can be used to highlight that.*
+
+[character]: ../characters.md
+[status quo stories]: ./status_quo.md
+[Alan]: ../characters/alan.md
+[Grace]: ../characters/grace.md
+[Niklaus]: ../characters/niklaus.md
+[Barbara]: ../characters/barbara.md
+[htvsq]: ../how_to_vision/status_quo.md
+[cannot be wrong]: ../how_to_vision/comment.md#comment-to-understand-or-improve-not-to-negate-or-dissuade

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -88,7 +88,7 @@ async fn get_products_handler(state: State) -> HandlerResult {
 }
 ```
 
-It's still not fantastically ergonomic though. Because the handler takes ownership of State and returns it in tuples in the result, Alan can't use the `?` operator inside his http request handlers. If he tries use `?` in a handler, like this:
+It's still not fantastically ergonomic though. Because the handler takes ownership of State and returns it in tuples in the result, Alan can't use the `?` operator inside his http request handlers. If he tries to use `?` in a handler, like this:
 
 ```rust
 async fn get_products_handler(state: State) -> HandlerResult {

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -1,13 +1,5 @@
 # 😱 Status quo stories: Template
 
-*This is a template for adding new "status quo" stories. To propose a new status quo PR, do the following:*
-
-* *Create a new file in the [`status_quo`] directory named something like `Alan_tries_to_foo.md` or `Grace_does_bar.md`, and start from [the raw source from this template]. You can replace all the italicized stuff. :)*
-* *Do not add a link to your story to the [`SUMMARY.md`] file; we'll do it after merging, otherwise there will be too many conflicts.*
-
-*For more detailed instructions, see the [How To Vision: Status Quo] page!*
-
-*If you're looking for ideas of what to write about, take a look at the [open issues]. You can also [open an issue of your own] to throw out an idea for others.*
 
 [How To Vision: Status Quo]: ../how_to_vision/status_quo.md
 [the raw source from this template]: https://raw.githubusercontent.com/rust-lang/wg-async-foundations/master/src/vision/status_quo/template.md
@@ -25,10 +17,6 @@ If you would like to expand on this story, or adjust the answers to the FAQ, fee
 
 ## The story
 
-*Write your story here! Feel free to add subsections, citations, links, code examples, whatever you think is best.*
-
-## 🤔 Frequently Asked Questions
-
 [YouBuy](../projects/YouBuy.md) is written using an async web framework that predates the stabilization of async function syntax. When Alan joins the company, it is using async functions for its business logic, but can't use them for request handlers because the framework doesn't support it yet. It requires the handler's return value to be `Box<dyn Future<...>>`. Rather than switching YouBuy to a different web framework, Alan decides to contribute to the web framework himself.
 
 After a bit of a slog, he manages to make the web framework capable of using an `async fn` as an http request handler. He does this by making a wrapper function that boxes up the `impl Future`.
@@ -41,6 +29,7 @@ A month later, one of the contributors finds a forum comment by Barbara explaini
 
 When Alan sees another open source project struggling with the same issue, he notices that Barbara has helped them out as well.
 
+## 🤔 Frequently Asked Questions
 
 * **What are the morals of the story?**
     * Callback-based APIs with async callbacks are a bit fiddly, because of the `impl Future` return type, but not insurmountable.

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -202,15 +202,22 @@ When Alan sees another open source project struggling with the same issue, he no
 
 ## 🤔 Frequently Asked Questions
 
-* **What are the morals of the story?**
-    * Callback-based APIs with async callbacks are a bit fiddly, because of the `impl Future` return type forcing you to write where-clause-soup, but not insurmountable.
-    * Callback-based APIs with async callbacks that borrow their arguments are almost impossible to write without help.
-* **What are the sources for this story?**
-    * This is from the author's [own experience](https://github.com/rust-lang/wg-async-foundations/issues/78#issuecomment-808193936).
-* **Why did you choose Alan/YouBuy to tell this story?**
-    * Callback-based apis are a super-common way to interact with web frameworks. I'm not sure how common they are in other fields.
-* **How would this story have played out differently for the other characters?**
-    * I suspect that even many Barbara-shaped developers would struggle with this problem.
+### What are the morals of the story?
+
+* Callback-based APIs with async callbacks are a bit fiddly, because of the `impl Future` return type forcing you to write where-clause-soup, but not insurmountable.
+* Callback-based APIs with async callbacks that borrow their arguments are almost impossible to write without help.
+
+### What are the sources for this story?
+
+* This is from the author's [own experience](https://github.com/rust-lang/wg-async-foundations/issues/78#issuecomment-808193936).
+
+### Why did you choose Alan/YouBuy to tell this story?
+
+* Callback-based apis are a super-common way to interact with web frameworks. I'm not sure how common they are in other fields.
+
+### How would this story have played out differently for the other characters?
+
+* I suspect that even many Barbara-shaped developers would struggle with this problem.
 
 [character]: ../characters.md
 [status quo stories]: ./status_quo.md

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -137,16 +137,16 @@ and then register it with:
 
 but Alan can't work out how to express the type signature for the `.to_async_borrowing()` helper function. He submits his `.to_async()` pull-request upstream as-is, but it nags on his mind that he has been defeated.
 
-Shortly afterwards, someone raises a bug about `?`, and a few other web framework contributors try to get it to work, but they also get stuck. When Alan tries it, the compiler diagnostics keep sending him around in circles. He can work out how to express the lifetimes for a function that returns a `Box<dyn Future + 'a>` but not an `impl Future` because of how where clauses are expressed. Alan longs to be able to say "this function takes an async function as a callback" (`fn register_handler(handler: impl async Fn(state: &mut State) -> Result<Response, Error>)`) and have Rust elide the lifetimes for him, like how they are elided for async functions.
+Shortly afterwards, someone raises a bug about `?`, and a few other web framework contributors try to get it to work, but they also get stuck. When Alan tries it, the compiler diagnostics keep sending him around in circles <!-- TODO: examples of this. Mabye move this into the paragraph above? -->. He can work out how to express the lifetimes for a function that returns a `Box<dyn Future + 'a>` but not an `impl Future` because of how where clauses are expressed. Alan longs to be able to say "this function takes an async function as a callback" (`fn register_handler(handler: impl async Fn(state: &mut State) -> Result<Response, Error>)`) and have Rust elide the lifetimes for him, like how they are elided for async functions.
 
-A month later, one of the contributors finds a forum comment by Barbara explaining how to express what the Alan is after (using higher-order lifetimes and a helper trait). They implement this and merge it.
+A month later, one of the contributors finds a forum comment by [Barbara] explaining how to express what Alan is after (using higher-order lifetimes and a helper trait). They implement this and merge it <!-- TODO: link to PR and copy final implementation here. -->.
 
 When Alan sees another open source project struggling with the same issue, he notices that Barbara has helped them out as well.
 
 ## 🤔 Frequently Asked Questions
 
 * **What are the morals of the story?**
-    * Callback-based APIs with async callbacks are a bit fiddly, because of the `impl Future` return type, but not insurmountable.
+    * Callback-based APIs with async callbacks are a bit fiddly, because of the `impl Future` return type forcing you to write where-clause-soup, but not insurmountable.
     * Callback-based APIs with async callbacks that borrow their arguments are almost impossible to write without help.
 * **What are the sources for this story?**
     * This is from the author's [own experience](https://github.com/rust-lang/wg-async-foundations/issues/78#issuecomment-808193936).

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -27,8 +27,8 @@ fn get_products_handler(state: State) -> Pin<Box<HandlerFuture>> {
         let repo = Repo::borrow_from(&state);
         let result = repo.run(move |conn| products.load::<Product>(&conn)).await;
         match result {
-            Ok(users) => {
-                let body = serde_json::to_string(&users).expect("Failed to serialize users.");
+            Ok(prods) => {
+                let body = serde_json::to_string(&prods).expect("Failed to serialize prods.");
                 let res = create_response(&state, StatusCode::OK, mime::APPLICATION_JSON, body);
                 Ok((state, res))
             }
@@ -67,8 +67,8 @@ async fn get_products_handler(state: State) -> HandlerResult {
     let repo = Repo::borrow_from(&state);
     let result = repo.run(move |conn| products.load::<Product>(&conn)).await;
     match result {
-        Ok(users) => {
-            let body = serde_json::to_string(&users).expect("Failed to serialize users.");
+        Ok(prods) => {
+            let body = serde_json::to_string(&prods).expect("Failed to serialize prods.");
             let res = create_response(&state, StatusCode::OK, mime::APPLICATION_JSON, body);
             Ok((state, res))
         }

--- a/src/vision/status_quo/alan_writes_a_web_framework.md
+++ b/src/vision/status_quo/alan_writes_a_web_framework.md
@@ -43,7 +43,7 @@ and then it is registered like this:
     router_builder.get("/").to(get_products_handler);
 ```
 
-The handler code is forced to drift to the right a lot, because of the async block, and the lack of ability to use `?` forces the use of a match block, which drifts even further to the right.
+The handler code is forced to drift to the right a lot, because of the async block, and the lack of ability to use `?` forces the use of a match block, which drifts even further to the right. This goes against [what he has learned from his days writing go](https://github.com/uber-go/guide/blob/master/style.md#reduce-nesting).
 
 Rather than switching YouBuy to a different web framework, Alan decides to contribute to the web framework himself. After a bit of a slog and a bit of where-clause-soup, he manages to make the web framework capable of using an `async fn` as an http request handler. He does this by extending the router builder with a closure that boxes up the `impl Future` from the async fn and then passes that closure on to `.to()`.
 


### PR DESCRIPTION
This PR contains a write-up of my experiences from https://github.com/rust-lang/wg-async-foundations/issues/78#issuecomment-808193936 

There is a bit of solutionising towards the end. I can rip that out if you want:

> Alan longs to be able to say "this function takes an async function as a callback" (`fn register_handler(handler: impl async Fn(state: &mut State) -> Result<Response, Error>)`) and have Rust elide the lifetimes for him, like how they are elided for async functions.

It's also super-trimmed-down compared to my full experiences, and we could probably flesh out the morals a bit better.