### PR TITLE
Don't run "mdbook test" in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           tag=$(curl -LsSf https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r '.tag_name')
           curl -LsSf https://github.com/rust-lang/mdBook/releases/download/$tag/mdbook-$tag-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
           echo $(pwd) >> $GITHUB_PATH
-      - run: mdbook build && mdbook test
+      - run: mdbook build
       - uses: rust-lang/simpleinfra/github-actions/static-websites@master
         with:
           deploy_dir: book


### PR DESCRIPTION
All this does is use rustdoc to run rust code blocks
but since we're ignoring all of the code blocks anyway,
there's no point in running `mdbook test`