### PR TITLE
Update alan_tries_a_socket_sink.md

### DIFF
--- a/src/vision/status_quo/alan_tries_a_socket_sink.md
+++ b/src/vision/status_quo/alan_tries_a_socket_sink.md
@@ -122,6 +122,7 @@ A few weeks later, Alan's work at his project at work is merged with his new for
 * <https://twitter.com/cryptoquick/status/1370143022801846275>
 * <https://twitter.com/cryptoquick/status/1370155726056738817>
 * <https://blog.yoshuawuyts.com/rust-streams/#why-we-do-not-talk-about-the-sink-trait>
+* [[C++] Throwing Out The Kitchen Sink](https://thephd.github.io/output-ranges)
 ### **Why did you choose [Alan](../characters/alan.md) to tell this story?**
 * Alan is more representative of the original author's background in JS, TypeScript, and NodeJS.
 ### **How would this story have played out differently for the other characters?**


### PR DESCRIPTION
This adds an additional source to the "Alan tries the kitchen sink" story, sharing coverage of how sinks are playing out in C++, which has partially informed the omission of the Sink from the http-rs ecosystem. Thanks!