### PR TITLE
Add more how to help guidance

### DIFF
--- a/src/vision/roadmap.md
+++ b/src/vision/roadmap.md
@@ -11,6 +11,9 @@ We categorize the goals and initiatives into four states:
 | ✋ | Help wanted: Seeking an [owner] to pursue this! Talk to the [wg leads] if you are interested. |
 | 💤 | Paused: we are waiting to work on this until some other stuff gets done. |
 
+Some goals and initiatives have further "how to help" instructions for those wanting to contribute.
+These are marked by the 🛠️ symbol.
+
 [owner]: ./how_to_vision/owners.md
 
 ## Impact and milesetones
@@ -42,7 +45,7 @@ Clicking on active initiatives also shows a list of *milestones*. These mileston
 | &nbsp;&nbsp;↳ [Timer traits] | 💤 | ▰▱▱▱▱▱ | |
 | &nbsp;&nbsp;↳ [Spawn traits] | 💤 | ▰▱▱▱▱▱ | |
 | &nbsp;&nbsp;↳ [Runtime trait] | 💤 | ▰▱▱▱▱▱ | |
-| 🔻 [Polish] | 🦀  | ▰▰▰▱▱▱ | [eholk] |
+| 🔻 [Polish] [[🛠️][how-to-help-polish]] | 🦀  | ▰▰▰▱▱▱ | [eholk] |
 | &nbsp;&nbsp;↳ [Error messages] | 💤 | ▰▰▰▱▱▱ | |
 | &nbsp;&nbsp;↳ [Must not suspend lint] | 🦀 | ▰▰▰▰▱▱ | |
 | &nbsp;&nbsp;↳ [Blocking function lint] | 💤 | ▰▰▱▱▱▱ | |
@@ -79,6 +82,7 @@ Clicking on active initiatives also shows a list of *milestones*. These mileston
 [Spawn traits]: ./roadmap/portable/spawn.md
 [Runtime trait]: ./roadmap/portable/runtime.md
 [polish]: ./roadmap/polish.md
+[how-to-help-polish]: ./roadmap/polish.md#-how-to-help
 [Error messages]: ./roadmap/polish/error_messages.md
 [Blocking function lint]: ./roadmap/polish/lint_blocking_fns.md
 [Must not suspend lint]: ./roadmap/polish/lint_must_not_suspend.md

--- a/src/vision/roadmap/polish.md
+++ b/src/vision/roadmap/polish.md
@@ -13,7 +13,7 @@
   * Integration with low-level tooling and the like is high-quality.
   * The generated code from the compiler is high quality and performant.
 
-## How to Help
+## 🛠️ How to Help
 
 The goal of a highly polished async experience in Rust has many details and touches many aspects of the project, including both the async area in particular and the Rust project in general.
 This means there are lots of ways to get involved!

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -9,14 +9,21 @@ The leads of this working group are [@tmandry] and [@nikomatsakis]. Both of them
 [@tmandry]: https://github.com/tmandry
 [@nikomatsakis]: https://github.com/nikomatsakis
 
-## Getting involved
+## 🛠️ Getting involved
 
-There is a weekly [triage meeting] that takes place in our [Zulip stream][zulip]. Feel free to stop by then (or any time!) to introduce yourself. 
+There is a weekly [triage meeting] that takes place in our [Zulip stream][zulip]. Feel free to stop by then (or any time!) to introduce yourself.
 
 If you're interested in fixing bugs, though, there is no need to wait for the meeting! [Take a look at the instructions here.][fix-bugs]
 
+We are actively working on bringing the [async vision] to reality, so there are lots of ways to help.
+Check out the [Roadmap] to see the various things we are working on.
+Each of the high level goals should have further instructions for how to get starting helping with that goal in particular.
+Look for the 🛠️ icon, which highlights areas where further how to help resources are available.
+
 [triage meeting]: ./triage.md
 [fix-bugs]: ./triage.md#so-you-want-to-fix-a-bug
+[async vision]: ./vision.md
+[Roadmap]: ./vision/roadmap.md
 
 ## What is the goal of this working group?
 


### PR DESCRIPTION
This adds additional detail on the welcome page with links to the roadmap, and also establishes the convention of using 🛠️ to identify sections that include more how to help guidance.